### PR TITLE
Fix of errors and warnings

### DIFF
--- a/lib/alchemic_avatar.ex
+++ b/lib/alchemic_avatar.ex
@@ -56,7 +56,7 @@ defmodule AlchemicAvatar do
   end
 
   defp dir_path(identity) do
-    path = "#{cache_path}/#{identity.letter}/#{identity.color |> Enum.join("_")}"
+    path = "#{cache_path()}/#{identity.letter}/#{identity.color |> Enum.join("_")}"
     :code.priv_dir(AlchemicAvatar.Config.app_name) |> Path.join(path)
   end
 
@@ -95,7 +95,7 @@ defmodule AlchemicAvatar do
       "-gravity", "center",
       "-thumbnail", "#{width}x#{height}^",
       "-extent", "#{width}x#{height}",
-      "-interpolate", "bicubic",
+      "-interpolate", "catrom",
       "-unsharp", "2x0.5+0.7+0",
       "-quality", "98",
       "#{to}"

--- a/lib/color.ex
+++ b/lib/color.ex
@@ -12,13 +12,13 @@ defmodule AlchemicAvatar.Color do
 
   def google(username) do
     index = do_google_username(username)
-    google_tuple |> elem(index)
+    google_tuple() |> elem(index)
   end
 
   def iwanthue(username) do
-    len = tuple_size(iwanthue_tuple)
+    len = tuple_size(iwanthue_tuple())
     index = username |> hexdigest |> digest_to_index(len)
-    iwanthue_tuple |> elem(index)
+    iwanthue_tuple() |> elem(index)
   end
 
   defp do_google_username(username) do
@@ -30,7 +30,7 @@ defmodule AlchemicAvatar.Color do
       <<char, _rest::binary>> when char in 48..57 ->
        <<char>> |> String.to_integer
       <<string::binary>> ->
-        len = tuple_size(google_tuple)
+        len = tuple_size(google_tuple())
         string |> hexdigest |> digest_to_index(len)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,11 @@ defmodule AlchemicAvatar.Mixfile do
     [app: :alchemic_avatar,
      version: "0.1.2",
      elixir: "~> 1.2",
-     description: description,
+     description: description(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps,
+     package: package(),
+     deps: deps(),
      docs: [extras: ["README.md"] ]
     ]
   end


### PR DESCRIPTION
Hello, I was receiving a lot of warnings and errors (probably because this module wasn't updated for quite some time) so decided to fix those and push changes back.

1)  Error: `convert: unrecognized interpolate method `bicubic' @ error/convert.c/ConvertImageCommand/1917.`
Fix: ImageMagick have changed the name from bicubic to catrom as can be seen here: https://www.imagemagick.org/script/command-line-options.php#interpolate

2) Lot of compiler warnings about variable names:
`warning: variable "google_tuple" does not exist and is being expanded to "google_tuple()", please use parentheses to remove the ambiguity or change the variable name`
As of Elixir 1.3 function calls without any parameters have to be called with parenthesis otherwise compiler complains.